### PR TITLE
Remake interface to common PostCSS plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 var parse = require('css-annotation').parse
 
-module.exports = function plugin () {
+module.exports = function plugin (css) {
 
     return function (root) {
         var matchedRules = []
-
-        var annotations = parse(root)
+        
+        //ensure css object
+        css = css || root;
+        
+        var annotations = parse(css);
 
         root.eachRule(function (node) {
             if (checkInclude(node)) {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
 var parse = require('css-annotation').parse
 
-module.exports = function plugin (css, options) {
-    options = options || {}
-
-    var annotations = parse(css)
+module.exports = function plugin () {
 
     return function (root) {
         var matchedRules = []
+
+        var annotations = parse(root)
 
         root.eachRule(function (node) {
             if (checkInclude(node)) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -20,7 +20,7 @@ var include = require('postcss-include')
 var css = fs.readFileSync('input.css', 'utf-8')
 
 var output = postcss(css)
-  .use(include(css))
+  .use(include())
   .process(css)
   .css
 ```


### PR DESCRIPTION
Hey there. 

I ran into problems using this plugin through postcss-cli - like that:
`postcss index.css -u postcss-include -o build.css`
The exception is thrown because `css` variable [here](https://github.com/morishitter/postcss-include/blob/master/index.js#L6) is not passed as argument and is undefined. Here's postcss-color-function plugin example code - [link](https://github.com/postcss/postcss-color-function/blob/master/index.js#L11) - no css argument used.

I changed this library code and now it works well but it would be cool if all the plugins used in AtCSS were compatible with postcss-cli syntax. It'll require some changes [here](https://github.com/morishitter/atcss/blob/master/index.js#L24) and maybe somewhere else.

What do you think about this change?
